### PR TITLE
added sinuosity() and unit test

### DIFF
--- a/gisutils/algo.py
+++ b/gisutils/algo.py
@@ -59,6 +59,7 @@ def average_slope(gdf, dem, dem_affine, absolute=True, as_pct=True):
 
     return slope * factor
 
+
 def compute_sinuosity(gdf):
     """
     Computes the sinuosity between the first and last coordinates of
@@ -86,14 +87,13 @@ def compute_sinuosity(gdf):
     # coords of the starts of the line
     x1, y1 = _get_nth_points_in_lines(gdf, 0)
 
-
     # coords of the ends of the lines
     x2, y2 = _get_nth_points_in_lines(gdf, -1)
 
-    dx = x2.values-x1.values
-    dy = y2.values-y1.values
+    dx = x2.values - x1.values
+    dy = y2.values - y1.values
 
-    distance = ((dx)**2 + (dy)**2)**.5
+    distance = (dx**2 + dy**2) ** 0.5
 
     sinuosity = numpy.abs(gdf['geometry'].length / distance)
 

--- a/gisutils/algo.py
+++ b/gisutils/algo.py
@@ -58,3 +58,43 @@ def average_slope(gdf, dem, dem_affine, absolute=True, as_pct=True):
         factor = 100
 
     return slope * factor
+
+def compute_sinuosity(gdf):
+    """
+    Computes the sinuosity between the first and last coordinates of
+    a line.
+
+    Returns a `sinuosity` GeoSeries (float) containing the result
+    of the sinuosity calculation.
+
+    Parameters
+    ----------
+    gdf : geopandas.GeoDataFrame
+        A geodataframe of simple line geometries.
+
+    Returns
+    -------
+    sinuosity : geopandas.GeoSeries
+
+    Notes
+    -----
+    The input parameters need to to be in the same coordinate reference
+    system. This function does not reproject the information in any way.
+
+    """
+
+    # coords of the starts of the line
+    x1, y1 = _get_nth_points_in_lines(gdf, 0)
+
+
+    # coords of the ends of the lines
+    x2, y2 = _get_nth_points_in_lines(gdf, -1)
+
+    dx = x2.values-x1.values
+    dy = y2.values-y1.values
+
+    distance = ((dx)**2 + (dy)**2)**.5
+
+    sinuosity = numpy.abs(gdf['geometry'].length / distance)
+
+    return sinuosity

--- a/gisutils/tests/test_algo.py
+++ b/gisutils/tests/test_algo.py
@@ -33,3 +33,22 @@ def test_average_slope():
     result = algo.average_slope(lines, hill, trans)
 
     pdtest.assert_series_equal(result, expected)
+
+def test_compute_sinuosity():
+    _lines = [
+        geometry.LineString(coordinates=[(0, 5), (10, 5)]),
+        geometry.LineString(coordinates=[(0, 0), (0, 10), (10, 10)]),
+        geometry.LineString(coordinates=[(0, 0), (5, 5), (5, 0), (0, 0)]),
+    ]
+
+    lines = geopandas.GeoDataFrame(geometry=_lines)
+
+    expected = pandas.Series([
+        1.000000,
+        1.414213,
+        numpy.inf,
+    ])
+
+    result = algo.compute_sinuosity(lines)
+
+    pdtest.assert_series_equal(result, expected)

--- a/gisutils/tests/test_algo.py
+++ b/gisutils/tests/test_algo.py
@@ -34,6 +34,7 @@ def test_average_slope():
 
     pdtest.assert_series_equal(result, expected)
 
+
 def test_compute_sinuosity():
     _lines = [
         geometry.LineString(coordinates=[(0, 5), (10, 5)]),


### PR DESCRIPTION
This PR adds the ability to compute sinuosity of a line feature. Computed as the geometry attribute `gdf['geometry'].Length` of a GeoDataFrame line feature divided by the distance between coordinates of the end points. A unit test is included.